### PR TITLE
feat: Add MinIO storage backend support alongside MongoDB and MySQL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,8 @@ ENVIRONMENT=development
 PORT=8080
 COOKIE_SECRET=11oETzKXQAGaYdkL5gEmGeJJFuYh7EQnp2XdTP1o/Vo=
 
-# Storage Backend (mongodb, mysql, s3)
-STORAGE_BACKEND=mongodb
+# Storage Backend (mongodb, mysql, minio, s3)
+STORAGE_BACKEND=minio
 
 # MongoDB Configuration
 MONGO_URI=mongodb://localhost:27017
@@ -17,6 +17,13 @@ AWS_ACCESS_KEY_ID=your_aws_access_key
 AWS_SECRET_ACCESS_KEY=your_aws_secret_key
 AWS_REGION=us-east-1
 S3_BUCKET=aspiring-cloud-storage
+
+# MinIO
+MINIO_ENDPOINT=localhost:9000
+MINIO_ACCESS_KEY=minioadmin
+MINIO_SECRET_KEY=minioadmin
+MINIO_BUCKET=touchcalc-storage
+MINIO_SSL=false
 
 # Email Configuration
 FROM_EMAIL=aspiring.investments@gmail.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,15 @@ services:
       - AWS_REGION=${AWS_REGION:-us-east-1}
       - S3_BUCKET=${S3_BUCKET:-aspiring-cloud-storage}
       - FROM_EMAIL=${FROM_EMAIL:-aspiring.investments@gmail.com}
+      - STORAGE_BACKEND=${STORAGE_BACKEND:-mongodb}
+      - MONGO_URI=${MONGO_URI:-mongodb://mongodb:27017}
+      - MONGO_DATABASE=${MONGO_DATABASE:-touchcalc}
+      - MYSQL_DSN=${MYSQL_DSN:-root:password@tcp(mysql:3306)/touchcalc}
+      - MINIO_ENDPOINT=${MINIO_ENDPOINT:-minio:9000}
+      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:-minioadmin}
+      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:-minioadmin}
+      - MINIO_BUCKET=${MINIO_BUCKET:-touchcalc-storage}
+      - MINIO_SSL=${MINIO_SSL:-false}
     env_file:
       - .env
     volumes:
@@ -22,6 +31,10 @@ services:
       - ./web/templates:/root/web/templates:ro
       - ./web/static:/root/web/static:ro
     restart: unless-stopped
+    depends_on:
+      - mongodb
+      - mysql
+      - minio
     healthcheck:
       test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8080/health"]
       interval: 30s
@@ -45,6 +58,65 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+
+  # MongoDB service
+  mongodb:
+    image: mongo:7.0
+    restart: unless-stopped
+    ports:
+      - "27017:27017"
+    environment:
+      - MONGO_INITDB_DATABASE=touchcalc
+    volumes:
+      - mongodb_data:/data/db
+    healthcheck:
+      test: ["CMD","mongosh", "--eval", "db.adminCommand('ping')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # MySQL service  
+  mysql:
+    image: mysql:8.0
+    restart: unless-stopped
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_DATABASE=touchcalc
+      - MYSQL_USER=touchcalc
+      - MYSQL_PASSWORD=touchcalc
+    volumes:
+      - mysql_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  # MinIO service
+  minio:
+    image: minio/minio:latest
+    restart: unless-stopped
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      - MINIO_ROOT_USER=minioadmin
+      - MINIO_ROOT_PASSWORD=minioadmin
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+volumes:
+  mongodb_data:
+  mysql_data:
+  minio_data:
 
 networks:
   default:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,12 @@ type Config struct {
     MongoURI       string
     MongoDatabase  string
     MySQLDSN       string
+
+	MinIOEndpoint   string
+    MinIOAccessKey  string
+    MinIOSecretKey  string
+    MinIOBucket     string
+    MinIOSSL        string
 }
 
 func Load() *Config {
@@ -43,6 +49,12 @@ func Load() *Config {
         MongoURI:      getEnv("MONGO_URI", "mongodb://localhost:27017"),
         MongoDatabase: getEnv("MONGO_DATABASE", "touchcalc"),
         MySQLDSN:      getEnv("MYSQL_DSN", "root:password@tcp(localhost:3306)/touchcalc"),
+
+		MinIOEndpoint:  getEnv("MINIO_ENDPOINT", "localhost:9000"),
+        MinIOAccessKey: getEnv("MINIO_ACCESS_KEY", "minioadmin"),
+        MinIOSecretKey: getEnv("MINIO_SECRET_KEY", "minioadmin"),
+        MinIOBucket:    getEnv("MINIO_BUCKET", "touchcalc-storage"),
+        MinIOSSL:       getEnv("MINIO_SSL", "false"),
 	}
 }
 

--- a/internal/storage/factory.go
+++ b/internal/storage/factory.go
@@ -34,11 +34,24 @@ func NewStorage(cfg *config.Config) (Storage, error) {
             return nil, fmt.Errorf("AWS credentials required for S3 storage")
         }
         log.Printf("Attempting to connect to AWS S3 bucket: %s", cfg.S3Bucket)
-        storage, err := NewS3Storage(cfg.S3Bucket)
+        storage, err := NewS3Storage(cfg.S3Bucket, "", cfg.AWSAccessKey, cfg.AWSSecretKey, cfg.AWSRegion, false)
         if err != nil {
             return nil, fmt.Errorf("failed to initialize S3 storage: %w", err)
         }
         log.Printf("Successfully connected to AWS S3")
+        return storage, nil
+        
+    case "minio":
+        if cfg.MinIOAccessKey == "" || cfg.MinIOSecretKey == "" {
+            return nil, fmt.Errorf("MinIO credentials required for MinIO storage")
+        }
+        log.Printf("Attempting to connect to MinIO at: %s, bucket: %s", cfg.MinIOEndpoint, cfg.MinIOBucket)
+        useSSL := cfg.MinIOSSL == "true"
+        storage, err := NewS3Storage(cfg.MinIOBucket, cfg.MinIOEndpoint, cfg.MinIOAccessKey, cfg.MinIOSecretKey, cfg.AWSRegion, useSSL)
+        if err != nil {
+            return nil, fmt.Errorf("failed to initialize MinIO storage: %w", err)
+        }
+        log.Printf("Successfully connected to MinIO")
         return storage, nil
         
     default:


### PR DESCRIPTION
# Add MinIO Storage Backend Support

## Overview
Adds MinIO as a fourth storage backend option alongside MongoDB, MySQL, and AWS S3 for local development and testing.

## Changes
- **Storage Factory**: Added MinIO case in `internal/storage/factory.go`
- **S3 Client**: Enhanced `internal/storage/s3.go` to support MinIO endpoints with path-style addressing
- **Configuration**: Added MinIO config fields in `internal/config/config.go`
- **Docker Compose**: Added MinIO service with MongoDB and MySQL services

## Storage Backends Available
- `mongodb` - MongoDB (existing)
- `mysql` - MySQL (existing) 
- `s3` - AWS S3 (existing)
- `minio` - MinIO S3-compatible (new)
